### PR TITLE
fix help message parsing error

### DIFF
--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -100,7 +100,7 @@ if options[:daemon]
     server.start(true)
   else
     if ENV['OS'] == 'Windows_NT' 
-      abort 'Daemonization is not supported on Windows. Running 'start chef-zero' will fork the process.'
+      abort 'Daemonization is not supported on Windows. Running \'start chef-zero\' will fork the process.'
     else
       abort 'Process.daemon requires Ruby >= 1.9'
     end


### PR DESCRIPTION
```
/usr/local/bundle/bin/chef-zero:22:in `load': /usr/local/bundle/gems/chef-zero-4.8.0/bin/chef-zero:103: syntax error, unexpected tIDENTIFIER, expecting keyword_end (SyntaxError)
...rted on Windows. Running 'start chef-zero' will fork the pro...
...                               ^
/usr/local/bundle/gems/chef-zero-4.8.0/bin/chef-zero:103: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
...dows. Running 'start chef-zero' will fork the process.'
...                               ^
	from /usr/local/bundle/bin/chef-zero:22:in `<main>'
```

This issue appears to have been caused by https://github.com/chef/chef-zero/commit/022397b795344045535c6ee34a38c0465d1c862e